### PR TITLE
Fix: 启用 reqwest socks 特性并统一 HTTP 客户端，确保 SOCKS5 代理生效

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1077,7 +1077,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -3176,7 +3175,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = "1"
 dirs = "6"
 toml = "0.9"
 toml_edit = "0.23"
-reqwest = { version = "0.12", features = ["json", "blocking"] }
+reqwest = { version = "0.12", features = ["json", "socks"] }
 tokio = { version = "1", features = ["full"] }
 urlencoding = "2.1"
 regex = "1"

--- a/src-tauri/src/http_client.rs
+++ b/src-tauri/src/http_client.rs
@@ -1,0 +1,29 @@
+//! HTTP 客户端构建工具：统一在一个地方处理代理与超时等配置。
+
+use reqwest::{self, Client};
+
+/// 构建一个遵循当前进程代理环境的 reqwest::Client。
+/// 优先读取由 ProxyService 写入的环境变量（HTTP_PROXY/HTTPS_PROXY/ALL_PROXY 等）。
+/// - 若配置了 `socks5://` 但构建失败，会返回更友好的错误提示。
+pub fn build_client() -> Result<Client, String> {
+    if let Some(proxy_url) = crate::ProxyService::get_current_proxy() {
+        match reqwest::Proxy::all(&proxy_url) {
+            Ok(proxy) => reqwest::Client::builder()
+                .proxy(proxy)
+                .build()
+                .map_err(|e| format!("Failed to build reqwest client: {}", e)),
+            Err(e) => {
+                // 为 SOCKS5 提供更友好的错误说明
+                if proxy_url.starts_with("socks5") {
+                    return Err(format!(
+                        "SOCKS5 代理初始化失败：{}。请确认已启用 reqwest 的 socks 特性并使用有效的 URL；若需要远程 DNS 解析，建议使用 socks5h://",
+                        e
+                    ));
+                }
+                Err(format!("Invalid proxy URL: {}", e))
+            }
+        }
+    } else {
+        Ok(reqwest::Client::new())
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 // lib.rs - 暴露服务层给 CLI 和 GUI 使用
 
+pub mod http_client;
 pub mod models;
 pub mod services;
 pub mod utils;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1397,19 +1397,9 @@ fn hide_window_to_tray<R: Runtime>(window: &WebviewWindow<R>) {
     }
 }
 
-// Helper: build reqwest client that respects the current proxy if configured
+// Helper: 统一使用库中的 HTTP 客户端构建逻辑（支持 SOCKS5 等代理）
 fn build_reqwest_client() -> Result<reqwest::Client, String> {
-    if let Some(proxy_url) = duckcoding::ProxyService::get_current_proxy() {
-        match reqwest::Proxy::all(&proxy_url) {
-            Ok(proxy) => reqwest::Client::builder()
-                .proxy(proxy)
-                .build()
-                .map_err(|e| format!("Failed to build reqwest client: {}", e)),
-            Err(e) => Err(format!("Invalid proxy URL: {}", e)),
-        }
-    } else {
-        Ok(reqwest::Client::new())
-    }
+    duckcoding::http_client::build_client()
 }
 
 fn main() {

--- a/src-tauri/src/services/version.rs
+++ b/src-tauri/src/services/version.rs
@@ -130,7 +130,11 @@ impl VersionService {
         &self,
         tool_id: &str,
     ) -> Result<(String, Option<String>, bool)> {
-        let response = reqwest::get(&self.mirror_api_url)
+        // 统一通过带代理的 Client 进行请求
+        let client = crate::http_client::build_client().map_err(|e| anyhow::anyhow!(e))?;
+        let response = client
+            .get(&self.mirror_api_url)
+            .send()
             .await?
             .json::<MirrorApiResponse>()
             .await?;
@@ -198,7 +202,9 @@ impl VersionService {
         #[cfg(debug_assertions)]
         println!("🔍 正在请求镜像站 API: {}", &self.mirror_api_url);
 
-        let response = reqwest::get(&self.mirror_api_url).await?;
+        // 统一通过带代理的 Client 进行请求
+        let client = crate::http_client::build_client().map_err(|e| anyhow::anyhow!(e))?;
+        let response = client.get(&self.mirror_api_url).send().await?;
 
         #[cfg(debug_assertions)]
         println!("✅ 收到响应，状态码: {}", response.status());


### PR DESCRIPTION
变更类型
- Fix（缺陷修复）

背景
- 前端允许选择 SOCKS5 代理，但后端 reqwest 未启用 socks 特性；部分请求仍直接使用 `reqwest::get`，绕过了统一的代理配置。
- 在启用 TUN/透明代理时，直连会被系统/内核层转发，容易误判“SOCKS5 已生效”。

修改内容
- Cargo：启用 reqwest `socks` 特性，移除未使用的 `blocking`。
- 新增模块：`src-tauri/src/http_client.rs`，集中构建带代理的 `reqwest::Client`。
- 统一调用：`VersionService` 去除 `reqwest::get`，改为复用统一 Client；`main.rs` 内部的构建函数委托到统一实现。
- 友好错误：若配置为 `socks5://` 且构建失败，返回更友好的错误提示（含 `socks5h://` 建议）。

验证
- 关闭系统代理/TUN 后，设置 SOCKS5 代理，点击“测试代理”与调用相关 API（生成 Key、用量/额度查询）均能正常返回。
- 执行 `npm run check` 全量通过（ESLint/Clippy/Prettier/Fmt）。

兼容性与影响范围
- 不涉及对外接口变更；HTTP 请求路径改为统一的 Client 构建，行为更一致。
- 编译体积/依赖轻微变化（移除 blocking、启用 socks）。

关联问题
- Fixes #18（reqwest 未启用 socks 导致 SOCKS5 代理可能未生效）

其他
- 后续如需支持远程 DNS 解析，可在 UI 增加 “SOCKS5(远程解析)” 选项（`socks5h://`）。
