### PR TITLE
refactor(backend): 统一日志系统，使用 tracing 替换 println/eprintln

### DIFF
--- a/src-tauri/src/commands/config_commands.rs
+++ b/src-tauri/src/commands/config_commands.rs
@@ -252,7 +252,7 @@ pub async fn configure_api(
     profile_name: Option<String>,
 ) -> Result<(), String> {
     #[cfg(debug_assertions)]
-    println!("Configuring {} (using ConfigService)", tool);
+    tracing::debug!(tool = %tool, "配置API（使用ConfigService）");
 
     // 获取工具定义
     let tool_obj = Tool::by_id(&tool).ok_or_else(|| format!("❌ 未知的工具: {}", tool))?;
@@ -273,7 +273,7 @@ pub async fn configure_api(
 #[tauri::command]
 pub async fn list_profiles(tool: String) -> Result<Vec<String>, String> {
     #[cfg(debug_assertions)]
-    println!("Listing profiles for {} (using ConfigService)", tool);
+    tracing::debug!(tool = %tool, "列出配置文件（使用ConfigService）");
 
     // 获取工具定义
     let tool_obj = Tool::by_id(&tool).ok_or_else(|| format!("❌ 未知的工具: {}", tool))?;
@@ -290,9 +290,10 @@ pub async fn switch_profile(
     manager_state: tauri::State<'_, ProxyManagerState>,
 ) -> Result<(), String> {
     #[cfg(debug_assertions)]
-    println!(
-        "Switching profile for {} to {} (using ConfigService)",
-        tool, profile
+    tracing::debug!(
+        tool = %tool,
+        profile = %profile,
+        "切换配置文件（使用ConfigService）"
     );
 
     // 获取工具定义
@@ -467,7 +468,7 @@ pub async fn switch_profile(
                         .await
                         .map_err(|e| format!("更新代理配置失败: {}", e))?;
 
-                    println!("✅ {} 透明代理配置已自动更新", tool);
+                    tracing::info!(tool = %tool, "透明代理配置已自动更新");
                 }
             }
 
@@ -494,12 +495,20 @@ pub async fn switch_profile(
                 drop(service);
             }
 
-            println!("✅ {} 配置已切换到 {} (代理模式)", tool, profile);
+            tracing::info!(
+                tool = %tool,
+                profile = %profile,
+                "配置已切换（代理模式）"
+            );
         }
     } else {
         // 非代理模式：正常激活配置
         ConfigService::activate_profile(&tool_obj, &profile).map_err(|e| e.to_string())?;
-        println!("✅ {} 配置已切换到 {}", tool, profile);
+        tracing::info!(
+            tool = %tool,
+            profile = %profile,
+            "配置已切换"
+        );
     }
 
     Ok(())
@@ -508,7 +517,11 @@ pub async fn switch_profile(
 #[tauri::command]
 pub async fn delete_profile(tool: String, profile: String) -> Result<(), String> {
     #[cfg(debug_assertions)]
-    println!("Deleting profile: tool={}, profile={}", tool, profile);
+    tracing::debug!(
+        tool = %tool,
+        profile = %profile,
+        "删除配置文件"
+    );
 
     // 获取工具定义
     let tool_obj = Tool::by_id(&tool).ok_or_else(|| format!("❌ 未知的工具: {}", tool))?;
@@ -517,7 +530,7 @@ pub async fn delete_profile(tool: String, profile: String) -> Result<(), String>
     ConfigService::delete_profile(&tool_obj, &profile).map_err(|e| e.to_string())?;
 
     #[cfg(debug_assertions)]
-    println!("Successfully deleted profile: {}", profile);
+    tracing::debug!(profile = %profile, "配置文件删除成功");
 
     Ok(())
 }

--- a/src-tauri/src/commands/proxy_commands.rs
+++ b/src-tauri/src/commands/proxy_commands.rs
@@ -104,11 +104,11 @@ pub async fn start_transparent_proxy(
     let (target_api_key, target_base_url) = TransparentProxyConfigService::get_real_config(&config)
         .map_err(|e| format!("获取真实配置失败: {e}"))?;
 
-    println!(
-        "🔑 真实 API Key: {}...",
-        &target_api_key[..4.min(target_api_key.len())]
+    tracing::debug!(
+        api_key_prefix = &target_api_key[..4.min(target_api_key.len())],
+        base_url = %target_base_url,
+        "真实 API 配置"
     );
-    println!("🌐 真实 Base URL: {target_base_url}");
 
     // 创建代理配置
     let proxy_config = ProxyConfig {
@@ -124,10 +124,16 @@ pub async fn start_transparent_proxy(
         if let Err(disable_err) =
             TransparentProxyConfigService::disable_transparent_proxy(&tool, &config)
         {
-            eprintln!("恢复 ClaudeCode 配置失败（代理启动错误后）: {disable_err}");
+            tracing::error!(
+                error = ?disable_err,
+                "恢复 ClaudeCode 配置失败（代理启动错误后）"
+            );
         }
         if let Err(save_err) = save_global_config(original_config).await {
-            eprintln!("恢复全局配置失败（代理启动错误后）: {save_err}");
+            tracing::error!(
+                error = ?save_err,
+                "恢复全局配置失败（代理启动错误后）"
+            );
         }
         return Err(format!("启动透明代理服务失败: {start_err}"));
     }
@@ -235,12 +241,11 @@ pub async fn update_transparent_proxy_config(
         .await
         .map_err(|e| format!("更新代理配置失败: {e}"))?;
 
-    println!("🔄 透明代理配置已更新:");
-    println!(
-        "   API Key: {}...",
-        &new_api_key[..4.min(new_api_key.len())]
+    tracing::info!(
+        api_key_prefix = &new_api_key[..4.min(new_api_key.len())],
+        base_url = %new_base_url,
+        "透明代理配置已更新"
     );
-    println!("   Base URL: {new_base_url}");
 
     Ok("✅ 透明代理配置已更新，无需重启".to_string())
 }
@@ -287,10 +292,10 @@ pub async fn test_proxy_request(
             scheme, auth, proxy_config.host, proxy_config.port
         );
 
-        println!(
-            "Testing with proxy: {}",
-            proxy_url.replace(&auth, "***:***@")
-        ); // 隐藏密码
+        tracing::debug!(
+            proxy_url = %proxy_url.replace(&auth, "***:***@"),
+            "测试代理请求"
+        );
 
         // 构建带代理的客户端
         match reqwest::Proxy::all(&proxy_url) {

--- a/src-tauri/src/commands/tool_commands.rs
+++ b/src-tauri/src/commands/tool_commands.rs
@@ -102,7 +102,7 @@ pub async fn install_tool(
 
     let force = force.unwrap_or(false);
     #[cfg(debug_assertions)]
-    println!("Installing {tool} via {method} (using InstallerService, force={force})");
+    tracing::debug!(tool = %tool, method = %method, force = force, "安装工具（使用InstallerService）");
 
     // 获取工具定义
     let tool_obj =
@@ -152,7 +152,7 @@ pub async fn check_update(tool: String) -> Result<UpdateResult, String> {
     apply_proxy_if_configured();
 
     #[cfg(debug_assertions)]
-    println!("Checking updates for {tool} (using VersionService)");
+    tracing::debug!(tool = %tool, "检查更新（使用VersionService）");
 
     let tool_obj = Tool::by_id(&tool).ok_or_else(|| format!("未知工具: {tool}"))?;
 
@@ -192,7 +192,7 @@ pub async fn check_all_updates() -> Result<Vec<UpdateResult>, String> {
     apply_proxy_if_configured();
 
     #[cfg(debug_assertions)]
-    println!("Checking updates for all tools (batch mode)");
+    tracing::debug!("批量检查所有工具更新");
 
     let version_service = VersionService::new();
     let version_infos = version_service.check_all_tools().await;
@@ -226,7 +226,7 @@ pub async fn update_tool(
 
     let force = force.unwrap_or(false);
     #[cfg(debug_assertions)]
-    println!("Updating {tool} (using InstallerService, force={force})");
+    tracing::debug!(tool = %tool, force = force, "更新工具（使用InstallerService）");
 
     // 获取工具定义
     let tool_obj =

--- a/src-tauri/src/commands/update_commands.rs
+++ b/src-tauri/src/commands/update_commands.rs
@@ -19,7 +19,7 @@ impl UpdateServiceState {
         let service_clone = service.clone();
         tauri::async_runtime::spawn(async move {
             if let Err(e) = service_clone.initialize().await {
-                eprintln!("Failed to initialize update service: {e}");
+                tracing::error!(error = ?e, "更新服务初始化失败");
             }
         });
         Self { service }

--- a/src-tauri/src/core/logger.rs
+++ b/src-tauri/src/core/logger.rs
@@ -127,10 +127,10 @@ pub fn init_logger(config: LogConfig) -> anyhow::Result<()> {
         let log_dir = match &config.log_dir {
             Some(dir) => dir.clone(),
             None => {
-                // 使用应用数据目录
-                let app_dir = dirs::data_local_dir()
-                    .ok_or_else(|| anyhow::anyhow!("无法获取应用数据目录"))?
-                    .join("DuckCoding")
+                // 使用用户主目录下的 .duckcoding/logs
+                let app_dir = dirs::home_dir()
+                    .ok_or_else(|| anyhow::anyhow!("无法获取用户主目录"))?
+                    .join(".duckcoding")
                     .join("logs");
 
                 std::fs::create_dir_all(&app_dir)?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -64,16 +64,16 @@ pub use ui::{
 pub async fn auto_start_proxies(manager: &ProxyManager) {
     use utils::config::read_global_config;
 
-    println!("🚀 检查透明代理自启动配置...");
+    tracing::info!("检查透明代理自启动配置");
 
     let config = match read_global_config() {
         Ok(Some(cfg)) => cfg,
         Ok(None) => {
-            println!("ℹ️ 未找到全局配置，跳过自启动");
+            tracing::debug!("未找到全局配置，跳过自启动");
             return;
         }
         Err(e) => {
-            eprintln!("❌ 读取配置失败: {}", e);
+            tracing::error!(error = ?e, "读取配置失败");
             return;
         }
     };
@@ -89,33 +89,39 @@ pub async fn auto_start_proxies(manager: &ProxyManager) {
 
         // 检查是否有保护密钥
         if tool_config.local_api_key.is_none() {
-            println!("⚠️ {} 未配置保护密钥，跳过自启动", tool_id);
+            tracing::warn!(tool_id = %tool_id, "未配置保护密钥，跳过自启动");
             continue;
         }
 
-        println!(
-            "🔄 正在自动启动 {} 代理 (端口 {})...",
-            tool_id, tool_config.port
+        tracing::info!(
+            tool_id = %tool_id,
+            port = tool_config.port,
+            "自动启动代理"
         );
 
         match manager.start_proxy(tool_id, tool_config.clone()).await {
             Ok(_) => {
-                println!("✅ {} 代理已自动启动", tool_id);
                 started_count += 1;
+                tracing::info!(tool_id = %tool_id, "代理启动成功");
             }
             Err(e) => {
-                eprintln!("❌ {} 代理自启动失败: {}", tool_id, e);
                 failed_count += 1;
+                tracing::error!(
+                    tool_id = %tool_id,
+                    error = ?e,
+                    "代理启动失败"
+                );
             }
         }
     }
 
     if started_count > 0 || failed_count > 0 {
-        println!(
-            "📊 自启动完成：成功 {} 个，失败 {} 个",
-            started_count, failed_count
+        tracing::info!(
+            started = started_count,
+            failed = failed_count,
+            "自启动代理完成"
         );
     } else {
-        println!("ℹ️ 没有配置自启动的代理");
+        tracing::debug!("没有配置自启动的代理");
     }
 }

--- a/src-tauri/src/services/proxy/proxy_manager.rs
+++ b/src-tauri/src/services/proxy/proxy_manager.rs
@@ -94,7 +94,7 @@ impl ProxyManager {
                 .await
                 .context(format!("停止 {} 代理失败", tool_id))?;
         } else {
-            println!("⚠️  {} 代理未运行或不存在", tool_id);
+            tracing::warn!(tool_id = %tool_id, "代理未运行或不存在");
         }
 
         Ok(())
@@ -108,7 +108,11 @@ impl ProxyManager {
         for tool_id in tool_ids {
             if let Some(instance) = instances.remove(&tool_id) {
                 if let Err(e) = instance.stop().await {
-                    eprintln!("⚠️  停止 {} 代理失败: {}", tool_id, e);
+                    tracing::error!(
+                        tool_id = %tool_id,
+                        error = ?e,
+                        "停止代理失败"
+                    );
                 }
             }
         }

--- a/src-tauri/src/services/proxy/proxy_service.rs
+++ b/src-tauri/src/services/proxy/proxy_service.rs
@@ -136,10 +136,10 @@ impl ProxyService {
                 let no_proxy = bypass_urls.join(",");
                 env::set_var("NO_PROXY", &no_proxy);
                 env::set_var("no_proxy", &no_proxy);
-                println!("Proxy bypass list: {no_proxy}");
+                tracing::debug!(no_proxy = %no_proxy, "代理绕过列表");
             }
 
-            println!("Proxy enabled: {proxy_url}");
+            tracing::info!(proxy_url = %proxy_url, "代理已启用");
         }
     }
 

--- a/src-tauri/src/services/proxy/transparent_proxy_config.rs
+++ b/src-tauri/src/services/proxy/transparent_proxy_config.rs
@@ -48,7 +48,10 @@ impl TransparentProxyConfigService {
         // 3. 修改工具配置指向本地代理
         Self::write_proxy_config(tool, local_proxy_port, local_proxy_key)?;
 
-        println!("✅ {} 透明代理已启用，配置已指向本地代理", tool.id);
+        tracing::info!(
+            tool_id = %tool.id,
+            "透明代理已启用，配置已指向本地代理"
+        );
 
         Ok(())
     }
@@ -92,7 +95,10 @@ impl TransparentProxyConfigService {
             real_model_provider.as_deref(),
         )?;
 
-        println!("✅ {} 透明代理已禁用，配置已恢复", tool.id);
+        tracing::info!(
+            tool_id = %tool.id,
+            "透明代理已禁用，配置已恢复"
+        );
 
         Ok(())
     }
@@ -116,7 +122,10 @@ impl TransparentProxyConfigService {
             global_config.transparent_proxy_real_base_url = Some(new_base_url.to_string());
         }
 
-        println!("✅ {} 透明代理真实配置已更新", tool.id);
+        tracing::info!(
+            tool_id = %tool.id,
+            "透明代理真实配置已更新"
+        );
 
         Ok(())
     }
@@ -128,7 +137,10 @@ impl TransparentProxyConfigService {
         local_proxy_key: &str,
     ) -> Result<()> {
         Self::write_proxy_config(tool, local_proxy_port, local_proxy_key)?;
-        println!("✅ {} 配置已更新指向本地代理", tool.id);
+        tracing::info!(
+            tool_id = %tool.id,
+            "配置已更新指向本地代理"
+        );
         Ok(())
     }
 

--- a/src-tauri/src/services/tool/downloader.rs
+++ b/src-tauri/src/services/tool/downloader.rs
@@ -131,7 +131,11 @@ impl FileDownloader {
             Ok(response) => Ok(response.content_length()),
             Err(e) => {
                 // 如果HEAD请求失败，可能是服务器不支持HEAD请求，记录但不阻断下载
-                eprintln!("Warning: Failed to get file size with HEAD request: {e}");
+                tracing::warn!(
+                    error = ?e,
+                    url = %url,
+                    "HEAD 请求获取文件大小失败"
+                );
                 Ok(None)
             }
         }

--- a/src-tauri/src/services/tool/installer.rs
+++ b/src-tauri/src/services/tool/installer.rs
@@ -191,7 +191,7 @@ impl InstallerService {
             let version_service = VersionService::new();
             match version_service.check_version(tool).await {
                 Ok(info) => version_info = Some(info),
-                Err(e) => eprintln!("⚠️  无法检查镜像状态: {e}"),
+                Err(e) => tracing::warn!(error = ?e, "无法检查镜像状态"),
             }
         }
 
@@ -328,7 +328,7 @@ impl InstallerService {
             let version_service = VersionService::new();
             match version_service.check_version(tool).await {
                 Ok(info) => version_info = Some(info),
-                Err(e) => eprintln!("⚠️  无法检查镜像状态: {e}"),
+                Err(e) => tracing::warn!(error = ?e, "无法检查镜像状态"),
             }
         }
 


### PR DESCRIPTION
本次重构将后端代码中的非结构化打印输出统一替换为结构化日志记录，提升调试和问题排查能力。

主要变更：
- 命令层：config_commands, proxy_commands, tool_commands, update_commands
- 核心模块：logger.rs, lib.rs, main.rs 添加日志初始化
- 代理服务：proxy_instance, proxy_manager, proxy_service, transparent_proxy
- 工具服务：downloader, installer, version, update_service
- 日志配置：调整日志存储路径到用户主目录 ~/.duckcoding/logs

日志改进：
- 使用 tracing 结构化日志，支持字段和上下文
- 区分不同日志级别：debug, info, warn, error
- 统一中文日志消息，便于理解
- 敏感信息部分隐藏（如 API Key）

Breaking Changes:
- 日志输出从控制台转向结构化文件
- 日志存储路径变更（从应用数据目录到用户主目录）

测试建议：
- 验证应用启动时日志系统初始化
- 检查代理服务的日志记录
- 确认错误场景下的日志输出