### PR TITLE
feat(logging): 实现完整的日志配置管理和热重载系统

### DIFF
--- a/src-tauri/src/commands/log_commands.rs
+++ b/src-tauri/src/commands/log_commands.rs
@@ -1,0 +1,72 @@
+// 日志配置管理命令
+// 提供前端查询和更新日志配置的接口
+
+use duckcoding::models::config::LogConfig;
+use duckcoding::utils::config::{read_global_config, write_global_config};
+use tauri::command;
+
+/// 检测当前是否为 Release 构建
+#[command]
+pub fn is_release_build() -> bool {
+    !cfg!(debug_assertions)
+}
+
+/// 获取当前日志配置
+///
+/// 从全局配置中读取日志系统配置并返回给前端
+#[command]
+pub async fn get_log_config() -> Result<LogConfig, String> {
+    let global_config = read_global_config().map_err(|e| e.to_string())?;
+
+    match global_config {
+        Some(config) => Ok(config.log_config.clone()),
+        None => {
+            // 配置不存在，返回默认配置
+            Ok(LogConfig::default())
+        }
+    }
+}
+
+/// 更新日志配置
+///
+/// 将新的日志配置保存到全局配置，并判断是否需要重启应用。
+/// 仅日志级别变更可以热重载，其他配置项需要重启应用生效。
+///
+/// # 返回值
+/// - 成功：返回提示消息
+///   - 可热重载：`"日志配置已更新并生效"`
+///   - 需要重启：`"日志配置已保存，需要重启应用后生效"`
+/// - 失败：返回错误信息
+#[command]
+pub async fn update_log_config(new_config: LogConfig) -> Result<String, String> {
+    tracing::info!(
+        level = new_config.level.as_str(),
+        format = ?new_config.format,
+        output = ?new_config.output,
+        "更新日志配置"
+    );
+
+    // 1. 读取当前全局配置
+    let mut global_config = read_global_config()
+        .map_err(|e| format!("读取配置失败: {}", e))?
+        .ok_or_else(|| "配置文件不存在".to_string())?;
+
+    // 2. 检查是否可以热重载
+    let old_config = &global_config.log_config;
+    let can_hot_reload = old_config.can_hot_reload(&new_config);
+
+    // 3. 保存新配置到文件
+    global_config.log_config = new_config.clone();
+    write_global_config(&global_config).map_err(|e| format!("保存配置失败: {}", e))?;
+
+    // 4. 如果只是日志级别变更，执行热重载
+    if can_hot_reload {
+        duckcoding::update_log_level(new_config.level).map_err(|e| format!("热重载失败: {}", e))?;
+
+        tracing::info!("日志配置已热重载");
+        Ok("日志配置已更新并生效".to_string())
+    } else {
+        tracing::warn!("日志配置已保存，但需要重启应用生效");
+        Ok("日志配置已保存，需要重启应用后生效".to_string())
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod config_commands;
+pub mod log_commands;
 pub mod proxy_commands;
 pub mod session_commands;
 pub mod stats_commands;
@@ -9,6 +10,7 @@ pub mod window_commands;
 
 // 重新导出所有命令函数
 pub use config_commands::*;
+pub use log_commands::*;
 pub use proxy_commands::*;
 pub use session_commands::*;
 pub use stats_commands::*;

--- a/src-tauri/src/core/http.rs
+++ b/src-tauri/src/core/http.rs
@@ -113,6 +113,7 @@ mod tests {
             session_endpoint_config_enabled: false,
             hide_transparent_proxy_tip: false,
             hide_session_config_hint: false,
+            log_config: crate::models::config::LogConfig::default(),
         };
 
         let url = build_proxy_url(&config).unwrap();

--- a/src-tauri/src/core/logger.rs
+++ b/src-tauri/src/core/logger.rs
@@ -1,243 +1,250 @@
-use std::{path::PathBuf, str::FromStr};
-use tracing::Level;
+use crate::models::config::{LogConfig, LogFormat, LogLevel, LogOutput};
+use std::sync::OnceLock;
 use tracing_appender::{non_blocking, rolling};
 use tracing_subscriber::{
     fmt::{self, format::FmtSpan},
     layer::SubscriberExt,
+    reload::{self, Handle},
     util::SubscriberInitExt,
     EnvFilter, Layer, Registry,
 };
 
-/// 日志级别
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LogLevel {
-    /// 追踪级别（最详细）
-    Trace,
-    /// 调试级别
-    Debug,
-    /// 信息级别
-    Info,
-    /// 警告级别
-    Warn,
-    /// 错误级别
-    Error,
-}
-
-impl LogLevel {
-    /// 转换为 tracing::Level
-    pub fn to_tracing_level(&self) -> Level {
-        match self {
-            LogLevel::Trace => Level::TRACE,
-            LogLevel::Debug => Level::DEBUG,
-            LogLevel::Info => Level::INFO,
-            LogLevel::Warn => Level::WARN,
-            LogLevel::Error => Level::ERROR,
-        }
-    }
-}
-
-impl FromStr for LogLevel {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let normalized = s.to_ascii_lowercase();
-        match normalized.as_str() {
-            "trace" => Ok(LogLevel::Trace),
-            "debug" => Ok(LogLevel::Debug),
-            "info" => Ok(LogLevel::Info),
-            "warn" => Ok(LogLevel::Warn),
-            "error" => Ok(LogLevel::Error),
-            _ => Err(()),
-        }
-    }
-}
-
-/// 日志配置
-#[derive(Debug, Clone)]
-pub struct LogConfig {
-    /// 日志级别
-    pub level: LogLevel,
-
-    /// 是否启用控制台输出
-    pub console_enabled: bool,
-
-    /// 是否启用文件输出
-    pub file_enabled: bool,
-
-    /// 日志文件目录
-    pub log_dir: Option<PathBuf>,
-
-    /// 日志文件名前缀
-    pub log_file_prefix: String,
-
-    /// 是否启用 JSON 格式（用于结构化日志）
-    pub json_format: bool,
-
-    /// 是否显示目标模块
-    pub show_target: bool,
-
-    /// 是否显示线程 ID
-    pub show_thread_ids: bool,
-
-    /// 是否显示时间戳
-    pub show_time: bool,
-
-    /// 是否启用 span 追踪
-    pub enable_spans: bool,
-}
-
-impl Default for LogConfig {
-    fn default() -> Self {
-        Self {
-            level: if cfg!(debug_assertions) {
-                LogLevel::Debug
-            } else {
-                LogLevel::Info
-            },
-            console_enabled: true,
-            file_enabled: true,
-            log_dir: None, // 默认使用应用数据目录
-            log_file_prefix: "duckcoding".to_string(),
-            json_format: false,
-            show_target: cfg!(debug_assertions),
-            show_thread_ids: false,
-            show_time: true,
-            enable_spans: cfg!(debug_assertions),
-        }
-    }
-}
+/// 全局日志级别 reload handle
+static LOG_LEVEL_HANDLE: OnceLock<Handle<EnvFilter, Registry>> = OnceLock::new();
 
 /// 初始化日志系统
 ///
+/// 支持基于配置的日志输出，包括：
+/// - 日志级别（trace/debug/info/warn/error）
+/// - 输出格式（JSON/纯文本）
+/// - 输出目标（控制台/文件/both）
+/// - 文件路径（用于文件输出）
+///
+/// # 热重载支持
+/// 日志级别可以通过 `update_log_level` 函数动态调整，无需重启应用。
+/// 其他配置（格式、输出目标、文件路径）需要重启应用后生效。
+///
 /// # 示例
 /// ```
-/// use duckcoding::core::logger::{LogConfig, init_logger};
+/// use duckcoding::models::config::LogConfig;
+/// use duckcoding::core::init_logger;
 ///
 /// let config = LogConfig::default();
-/// init_logger(config).expect("初始化日志系统失败");
+/// init_logger(&config).expect("初始化日志系统失败");
 /// ```
-pub fn init_logger(config: LogConfig) -> anyhow::Result<()> {
-    // 构建环境过滤器
-    let env_filter = build_env_filter(&config);
+pub fn init_logger(config: &LogConfig) -> anyhow::Result<()> {
+    // 1. 创建可重载的过滤层
+    let filter = create_env_filter(&config.level);
+    let (filter_layer, reload_handle) = reload::Layer::new(filter);
 
-    // 根据配置选择不同的初始化路径
-    if config.file_enabled {
-        // 同时启用控制台和文件输出
-        // 确定日志目录
-        let log_dir = match &config.log_dir {
-            Some(dir) => dir.clone(),
-            None => {
-                // 使用用户主目录下的 .duckcoding/logs
-                let app_dir = dirs::home_dir()
-                    .ok_or_else(|| anyhow::anyhow!("无法获取用户主目录"))?
-                    .join(".duckcoding")
-                    .join("logs");
+    // 2. 保存 reload handle（用于后续动态调整级别）
+    if LOG_LEVEL_HANDLE.set(reload_handle).is_err() {
+        anyhow::bail!("日志系统已初始化，不能重复初始化");
+    }
 
-                std::fs::create_dir_all(&app_dir)?;
-                app_dir
-            }
-        };
-
-        // 创建滚动日志文件（每天一个文件）
-        let file_appender = rolling::daily(log_dir, &config.log_file_prefix);
-        let (non_blocking, guard) = non_blocking(file_appender);
-
-        // 存储 guard 到全局静态变量（防止被 drop）
-        Box::leak(Box::new(guard));
-
-        // 构建文件输出层
-        let file_layer = if config.json_format {
-            // JSON 格式（用于日志分析工具）
-            fmt::layer()
-                .json()
-                .with_writer(non_blocking.clone())
-                .with_target(true)
-                .with_thread_ids(true)
-                .with_ansi(false) // 文件输出禁用颜色
-                .boxed()
-        } else {
-            // 普通格式
-            fmt::layer()
-                .with_writer(non_blocking)
-                .with_target(config.show_target)
-                .with_thread_ids(config.show_thread_ids)
-                .with_ansi(false)
-                .boxed()
-        };
-
-        Registry::default()
-            .with(env_filter)
-            .with(
-                fmt::layer()
-                    .with_target(config.show_target)
-                    .with_thread_ids(config.show_thread_ids)
-                    .with_ansi(true)
-                    .with_span_events(if config.enable_spans {
-                        FmtSpan::CLOSE
-                    } else {
-                        FmtSpan::NONE
-                    }),
-            )
-            .with(file_layer)
-            .init();
-    } else if config.console_enabled {
-        // 仅控制台输出
-        Registry::default()
-            .with(env_filter)
-            .with(
-                fmt::layer()
-                    .with_target(config.show_target)
-                    .with_thread_ids(config.show_thread_ids)
-                    .with_ansi(true)
-                    .with_span_events(if config.enable_spans {
-                        FmtSpan::CLOSE
-                    } else {
-                        FmtSpan::NONE
-                    }),
-            )
-            .init();
-    } else {
-        // 都不启用（极少情况）
-        Registry::default().with(env_filter).init();
+    // 3. 根据配置添加输出层并初始化
+    match (&config.output, &config.format) {
+        (LogOutput::Console, LogFormat::Text) => {
+            Registry::default()
+                .with(filter_layer)
+                .with(create_console_text_layer())
+                .init();
+        }
+        (LogOutput::Console, LogFormat::Json) => {
+            Registry::default()
+                .with(filter_layer)
+                .with(create_console_json_layer())
+                .init();
+        }
+        (LogOutput::File, LogFormat::Text) => {
+            let file_layer = create_file_text_layer(config.file_path.as_deref())?;
+            Registry::default()
+                .with(filter_layer)
+                .with(file_layer)
+                .init();
+        }
+        (LogOutput::File, LogFormat::Json) => {
+            let file_layer = create_file_json_layer(config.file_path.as_deref())?;
+            Registry::default()
+                .with(filter_layer)
+                .with(file_layer)
+                .init();
+        }
+        (LogOutput::Both, LogFormat::Text) => {
+            let file_layer = create_file_text_layer(config.file_path.as_deref())?;
+            Registry::default()
+                .with(filter_layer)
+                .with(create_console_text_layer())
+                .with(file_layer)
+                .init();
+        }
+        (LogOutput::Both, LogFormat::Json) => {
+            let file_layer = create_file_json_layer(config.file_path.as_deref())?;
+            Registry::default()
+                .with(filter_layer)
+                .with(create_console_json_layer())
+                .with(file_layer)
+                .init();
+        }
     }
 
     tracing::info!(
-        console_enabled = config.console_enabled,
-        file_enabled = config.file_enabled,
-        level = ?config.level,
-        "日志系统初始化成功"
+        level = config.level.as_str(),
+        format = ?config.format,
+        output = ?config.output,
+        file_path = ?config.file_path,
+        "日志系统初始化完成"
     );
 
     Ok(())
 }
 
-/// 构建环境过滤器
-fn build_env_filter(config: &LogConfig) -> EnvFilter {
-    // 优先从环境变量读取（支持运行时调整）
+/// 创建环境过滤器
+fn create_env_filter(level: &LogLevel) -> EnvFilter {
+    // 优先从环境变量读取（支持高级用户自定义）
     // 格式：RUST_LOG=debug 或 RUST_LOG=duckcoding=trace,reqwest=warn
     EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         // 默认配置：应用代码使用指定级别，第三方库使用 WARN
         EnvFilter::new(format!(
             "duckcoding={},hyper=warn,reqwest=warn,h2=warn,tokio=warn",
-            config.level.to_tracing_level()
+            level.as_str()
         ))
     })
 }
 
-/// 运行时调整日志级别
+/// 创建控制台文本格式输出层
+fn create_console_text_layer<S>() -> Box<dyn Layer<S> + Send + Sync + 'static>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    fmt::layer()
+        .with_writer(std::io::stdout)
+        .with_target(cfg!(debug_assertions))
+        .with_thread_ids(false)
+        .with_ansi(true)
+        .with_span_events(if cfg!(debug_assertions) {
+            FmtSpan::CLOSE
+        } else {
+            FmtSpan::NONE
+        })
+        .boxed()
+}
+
+/// 创建控制台 JSON 格式输出层
+fn create_console_json_layer<S>() -> Box<dyn Layer<S> + Send + Sync + 'static>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    fmt::layer()
+        .json()
+        .with_writer(std::io::stdout)
+        .with_target(cfg!(debug_assertions))
+        .with_thread_ids(false)
+        .with_ansi(true)
+        .boxed()
+}
+
+/// 创建文件文本格式输出层
+fn create_file_text_layer<S>(
+    file_path: Option<&str>,
+) -> anyhow::Result<Box<dyn Layer<S> + Send + Sync + 'static>>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    let log_dir = get_log_dir(file_path)?;
+    let file_appender = rolling::daily(log_dir, "duckcoding");
+    let (non_blocking, guard) = non_blocking(file_appender);
+
+    // 存储 guard 到全局静态变量（防止被 drop）
+    Box::leak(Box::new(guard));
+
+    Ok(fmt::layer()
+        .with_writer(non_blocking)
+        .with_target(cfg!(debug_assertions))
+        .with_thread_ids(false)
+        .with_ansi(false)
+        .boxed())
+}
+
+/// 创建文件 JSON 格式输出层
+fn create_file_json_layer<S>(
+    file_path: Option<&str>,
+) -> anyhow::Result<Box<dyn Layer<S> + Send + Sync + 'static>>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    let log_dir = get_log_dir(file_path)?;
+    let file_appender = rolling::daily(log_dir, "duckcoding");
+    let (non_blocking, guard) = non_blocking(file_appender);
+
+    // 存储 guard 到全局静态变量（防止被 drop）
+    Box::leak(Box::new(guard));
+
+    Ok(fmt::layer()
+        .json()
+        .with_writer(non_blocking)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_ansi(false)
+        .boxed())
+}
+
+/// 获取日志目录
+fn get_log_dir(file_path: Option<&str>) -> anyhow::Result<std::path::PathBuf> {
+    match file_path {
+        Some(path) => Ok(std::path::PathBuf::from(path)),
+        None => {
+            // 使用用户主目录下的 .duckcoding/logs
+            let app_dir = dirs::home_dir()
+                .ok_or_else(|| anyhow::anyhow!("无法获取用户主目录"))?
+                .join(".duckcoding")
+                .join("logs");
+
+            std::fs::create_dir_all(&app_dir)?;
+            Ok(app_dir)
+        }
+    }
+}
+
+/// 动态更新日志级别（热重载）
+///
+/// 此函数支持在应用运行时动态调整日志级别，无需重启。
+/// 仅限调整日志级别，格式和输出目标的变更仍需要重启应用。
 ///
 /// # 示例
 /// ```
-/// use duckcoding::core::logger::{LogLevel, set_log_level};
+/// use duckcoding::models::config::LogLevel;
+/// use duckcoding::core::update_log_level;
 ///
-/// set_log_level(LogLevel::Debug);
+/// update_log_level(LogLevel::Debug).expect("更新日志级别失败");
 /// ```
+pub fn update_log_level(new_level: LogLevel) -> anyhow::Result<()> {
+    let handle = LOG_LEVEL_HANDLE
+        .get()
+        .ok_or_else(|| anyhow::anyhow!("日志系统未初始化"))?;
+
+    let new_filter = create_env_filter(&new_level);
+    handle
+        .reload(new_filter)
+        .map_err(|e| anyhow::anyhow!("重载日志级别失败: {}", e))?;
+
+    tracing::info!(new_level = new_level.as_str(), "日志级别已动态更新");
+    Ok(())
+}
+
+/// 运行时调整日志级别（兼容旧接口）
+///
+/// # 弃用提示
+/// 此函数已弃用，请使用 `update_log_level` 代替。
+/// 旧版本通过环境变量调整，需要重启应用生效。
+/// 新版本使用 reload 机制，支持动态热重载。
+#[deprecated(
+    since = "1.3.0",
+    note = "请使用 update_log_level 代替，支持动态热重载"
+)]
+#[allow(dead_code)]
 pub fn set_log_level(level: LogLevel) {
-    // 注意：这需要重新初始化订阅者，或者使用 reload layer
-    // 这里提供一个简化版本，通过环境变量实现
-    std::env::set_var(
-        "RUST_LOG",
-        format!("duckcoding={}", level.to_tracing_level()),
-    );
-    tracing::warn!("日志级别已调整为 {:?}，需要重启应用生效", level);
+    if let Err(e) = update_log_level(level) {
+        tracing::error!(error = ?e, "更新日志级别失败");
+    }
 }

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -7,7 +7,11 @@ pub mod logger;
 pub use error::{AppError, AppResult, ErrorContext};
 pub use http::{build_http_client, get_global_client};
 pub use log_utils::{LogContext, Timer};
-pub use logger::{init_logger, set_log_level, LogConfig, LogLevel};
+#[allow(deprecated)]
+pub use logger::{init_logger, set_log_level, update_log_level};
+
+// 从 models 重新导出日志配置类型
+pub use crate::models::config::{LogConfig, LogFormat, LogLevel, LogOutput};
 
 // 重新导出 tracing 核心功能
 pub use tracing::{debug, error, info, instrument, span, trace, warn, Level};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,9 +37,10 @@ pub use models::update::PlatformInfo as UpdatePlatformInfo;
 pub use anyhow::{Context, Result};
 
 // 🆕 导出核心模块
+#[allow(deprecated)]
 pub use core::{
-    init_logger, set_log_level, AppError, AppResult, ErrorContext, LogConfig, LogContext, LogLevel,
-    Timer,
+    init_logger, set_log_level, update_log_level, AppError, AppResult, ErrorContext, LogConfig,
+    LogContext, LogFormat, LogLevel, LogOutput, Timer,
 };
 
 // 🆕 导出 UI 管理层

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -131,10 +131,17 @@ fn hide_window_to_tray<R: Runtime>(window: &WebviewWindow<R>) {
 
 fn main() {
     // 🆕 初始化日志系统（必须在最前面）
-    use duckcoding::core::{init_logger, LogConfig};
+    use duckcoding::core::init_logger;
+    use duckcoding::utils::config::read_global_config;
 
-    let log_config = LogConfig::default();
-    if let Err(e) = init_logger(log_config) {
+    // 从配置文件读取日志配置，失败则使用默认配置
+    let log_config = read_global_config()
+        .ok()
+        .flatten()
+        .map(|cfg| cfg.log_config)
+        .unwrap_or_default();
+
+    if let Err(e) = init_logger(&log_config) {
         // 日志系统初始化失败时使用 eprintln!（因为 tracing 还不可用）
         eprintln!("WARNING: Failed to initialize logging system: {}", e);
         // 继续运行，但日志功能将不可用
@@ -394,6 +401,10 @@ fn main() {
             get_platform_info,
             get_recommended_package_format,
             trigger_check_update,
+            // 日志管理命令
+            get_log_config,
+            update_log_config,
+            is_release_build,
         ]);
 
     // 使用自定义事件循环处理 macOS Reopen 事件

--- a/src/lib/tauri-commands.ts
+++ b/src/lib/tauri-commands.ts
@@ -60,6 +60,19 @@ export interface GlobalConfig {
   hide_transparent_proxy_tip?: boolean;
   // 是否隐藏会话级端点配置提示（默认显示）
   hide_session_config_hint?: boolean;
+  // 日志系统配置
+  log_config?: LogConfig;
+}
+
+export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error';
+export type LogFormat = 'json' | 'text';
+export type LogOutput = 'console' | 'file' | 'both';
+
+export interface LogConfig {
+  level: LogLevel;
+  format: LogFormat;
+  output: LogOutput;
+  file_path: string | null;
 }
 
 export interface GenerateApiKeyResult {
@@ -564,4 +577,29 @@ export async function updateSessionNote(sessionId: string, note: string | null):
     sessionId,
     note,
   });
+}
+
+// ==================== 日志配置管理 ====================
+
+/**
+ * 检测当前是否为 Release 构建
+ */
+export async function isReleaseBuild(): Promise<boolean> {
+  return await invoke<boolean>('is_release_build');
+}
+
+/**
+ * 获取当前日志配置
+ */
+export async function getLogConfig(): Promise<LogConfig> {
+  return await invoke<LogConfig>('get_log_config');
+}
+
+/**
+ * 更新日志配置
+ * @param newConfig - 新的日志配置
+ * @returns 提示消息，包含是否需要重启的信息
+ */
+export async function updateLogConfig(newConfig: LogConfig): Promise<string> {
+  return await invoke<string>('update_log_config', { newConfig });
 }

--- a/src/pages/SettingsPage/components/LogSettingsTab.tsx
+++ b/src/pages/SettingsPage/components/LogSettingsTab.tsx
@@ -1,0 +1,270 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { FileText, Info, Loader2, Save, AlertCircle } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import { getLogConfig, updateLogConfig, isReleaseBuild, type LogConfig } from '@/lib/tauri-commands';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+export function LogSettingsTab() {
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [isRelease, setIsRelease] = useState(false);
+  const [config, setConfig] = useState<LogConfig>({
+    level: 'info',
+    format: 'text',
+    output: 'both',
+    file_path: null,
+  });
+  const [originalConfig, setOriginalConfig] = useState<LogConfig | null>(null);
+
+  // 加载当前配置
+  const loadConfig = useCallback(async () => {
+    try {
+      setLoading(true);
+      const [currentConfig, releaseFlag] = await Promise.all([
+        getLogConfig(),
+        isReleaseBuild(),
+      ]);
+
+      setIsRelease(releaseFlag);
+
+      // Release 版本强制使用 File 输出
+      if (releaseFlag && currentConfig.output !== 'file') {
+        currentConfig.output = 'file';
+      }
+
+      setConfig(currentConfig);
+      setOriginalConfig(currentConfig);
+    } catch (error) {
+      console.error('Failed to load log config:', error);
+      toast({
+        title: '加载失败',
+        description: String(error),
+        variant: 'destructive',
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    loadConfig();
+  }, [loadConfig]);
+
+  // 判断配置是否需要重启
+  const needsRestart = (): boolean => {
+    if (!originalConfig) return false;
+    return (
+      config.format !== originalConfig.format ||
+      config.output !== originalConfig.output ||
+      config.file_path !== originalConfig.file_path
+    );
+  };
+
+  // 保存配置
+  const handleSave = async () => {
+    try {
+      setSaving(true);
+
+      // Release 版本强制使用 File 输出
+      const configToSave = isRelease
+        ? { ...config, output: 'file' as const }
+        : config;
+
+      const message = await updateLogConfig(configToSave);
+      setOriginalConfig(configToSave);
+      toast({
+        title: '保存成功',
+        description: message,
+      });
+    } catch (error) {
+      console.error('Failed to save log config:', error);
+      toast({
+        title: '保存失败',
+        description: String(error),
+        variant: 'destructive',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-12">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 rounded-lg border p-6">
+      <div className="flex items-center gap-2">
+        <FileText className="h-5 w-5" />
+        <h3 className="text-lg font-semibold">日志系统配置</h3>
+      </div>
+      <Separator />
+
+      <div className="space-y-6">
+        {/* 日志级别 */}
+        <div className="space-y-2">
+          <Label htmlFor="log-level">日志级别</Label>
+          <Select
+            value={config.level}
+            onValueChange={(value) =>
+              setConfig({ ...config, level: value as LogConfig['level'] })
+            }
+          >
+            <SelectTrigger id="log-level" className="shadow-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="trace">Trace（最详细）</SelectItem>
+              <SelectItem value="debug">Debug（调试）</SelectItem>
+              <SelectItem value="info">Info（信息）</SelectItem>
+              <SelectItem value="warn">Warn（警告）</SelectItem>
+              <SelectItem value="error">Error（错误）</SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            日志级别变更可以实时生效（热重载），无需重启应用
+          </p>
+        </div>
+
+        {/* 输出格式 */}
+        <div className="space-y-2">
+          <Label htmlFor="log-format">输出格式</Label>
+          <Select
+            value={config.format}
+            onValueChange={(value) =>
+              setConfig({ ...config, format: value as LogConfig['format'] })
+            }
+          >
+            <SelectTrigger id="log-format" className="shadow-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="text">纯文本格式</SelectItem>
+              <SelectItem value="json">JSON 格式</SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">格式变更需要重启应用后生效</p>
+        </div>
+
+        {/* 输出目标（Release 版本隐藏，强制使用文件输出） */}
+        {!isRelease && (
+          <div className="space-y-2">
+            <Label htmlFor="log-output">输出目标</Label>
+            <Select
+              value={config.output}
+              onValueChange={(value) =>
+                setConfig({ ...config, output: value as LogConfig['output'] })
+              }
+            >
+              <SelectTrigger id="log-output" className="shadow-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="console">仅控制台</SelectItem>
+                <SelectItem value="file">仅文件</SelectItem>
+                <SelectItem value="both">控制台和文件</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">输出目标变更需要重启应用后生效</p>
+          </div>
+        )}
+
+        {/* Release 版本提示 */}
+        {isRelease && (
+          <Alert className="border-blue-200 bg-blue-50 dark:bg-blue-950/30">
+            <Info className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+            <AlertDescription className="text-blue-800 dark:text-blue-200">
+              当前为 Release 版本，日志将自动输出到文件（无控制台输出）
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {/* 文件路径（Release 版本总是显示） */}
+        {(isRelease || config.output === 'file' || config.output === 'both') && (
+          <div className="space-y-2">
+            <Label htmlFor="log-file-path">日志文件目录</Label>
+            <Input
+              id="log-file-path"
+              placeholder="留空使用默认路径（~/.duckcoding/logs）"
+              value={config.file_path || ''}
+              onChange={(e) =>
+                setConfig({ ...config, file_path: e.target.value || null })
+              }
+              className="shadow-sm"
+            />
+            <p className="text-xs text-muted-foreground">
+              指定日志文件的保存目录。日志文件会按日期自动滚动（每日一个文件）
+            </p>
+          </div>
+        )}
+
+        {/* 热重载提示 */}
+        <div className="rounded-lg bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 p-4">
+          <div className="flex items-start gap-2">
+            <Info className="h-4 w-4 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" />
+            <div className="space-y-1 flex-1">
+              <p className="text-sm font-semibold text-blue-800 dark:text-blue-200">
+                关于热重载
+              </p>
+              <ul className="text-xs text-blue-700 dark:text-blue-300 space-y-1 list-disc list-inside">
+                <li>
+                  <strong>日志级别</strong>变更会立即生效，无需重启应用
+                </li>
+                <li>
+                  <strong>输出格式、输出目标、文件路径</strong>变更需要重启应用后生效
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        {/* 重启提示（需要重启时显示） */}
+        {needsRestart() && (
+          <Alert variant="default" className="border-orange-200 bg-orange-50 dark:bg-orange-950/30">
+            <AlertCircle className="h-4 w-4 text-orange-600 dark:text-orange-400" />
+            <AlertDescription className="text-orange-800 dark:text-orange-200">
+              当前配置包含需要重启应用才能生效的项目，保存后请重启 DuckCoding
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {/* 保存按钮 */}
+        <div className="flex justify-end pt-2">
+          <Button
+            onClick={handleSave}
+            disabled={saving}
+            className="shadow-md hover:shadow-lg transition-all"
+          >
+            {saving ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                保存中...
+              </>
+            ) : (
+              <>
+                <Save className="mr-2 h-4 w-4" />
+                保存日志配置
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/SettingsPage/index.tsx
+++ b/src/pages/SettingsPage/index.tsx
@@ -7,6 +7,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useSettingsForm } from './hooks/useSettingsForm';
 import { BasicSettingsTab } from './components/BasicSettingsTab';
 import { ProxySettingsTab } from './components/ProxySettingsTab';
+import { LogSettingsTab } from './components/LogSettingsTab';
 import { TransparentProxyMigrationNotice } from './components/TransparentProxyMigrationNotice';
 import { AboutTab } from './components/AboutTab';
 import type { GlobalConfig, UpdateInfo } from '@/lib/tauri-commands';
@@ -119,6 +120,7 @@ export function SettingsPage({
         <TabsList>
           <TabsTrigger value="basic">基本设置</TabsTrigger>
           <TabsTrigger value="proxy">代理设置</TabsTrigger>
+          <TabsTrigger value="log">日志配置</TabsTrigger>
           <TabsTrigger value="experimental">透明代理</TabsTrigger>
           <TabsTrigger value="about">关于</TabsTrigger>
         </TabsList>
@@ -155,6 +157,11 @@ export function SettingsPage({
             proxyBypassUrls={proxyBypassUrls}
             setProxyBypassUrls={setProxyBypassUrls}
           />
+        </TabsContent>
+
+        {/* 日志配置 */}
+        <TabsContent value="log" className="space-y-6">
+          <LogSettingsTab />
         </TabsContent>
 
         {/* 透明代理 (迁移提示) */}


### PR DESCRIPTION
添加功能完整的日志配置系统，支持运行时调整、多种输出格式和目标。

核心功能：
- 日志级别控制：trace/debug/info/warn/error 五级
- 输出格式选择：文本格式和 JSON 结构化格式
- 输出目标配置：控制台、文件、同时输出
- 热重载支持：运行时动态调整日志级别无需重启

后端实现：
- core/logger: 完全重构支持配置化初始化和热重载
- models/config: 添加 LogConfig、LogLevel、LogFormat、LogOutput 类型
- commands/log_commands: 新增日志配置管理 Tauri 命令
- main.rs: 应用启动时从配置文件读取日志配置

前端界面：
- SettingsPage/LogSettingsTab: 新增日志配置标签页
- tauri-commands.ts: 添加日志配置相关的 TypeScript 类型
- UI 支持：级别选择器、格式切换、输出目标配置、文件路径设置

技术特性：
- reload 机制：使用 tracing_subscriber::reload 实现热重载
- 滚动日志：按天自动滚动的日志文件管理
- 环境变量支持：高级用户可通过 RUST_LOG 自定义过滤规则
- 向后兼容：保留旧接口 set_log_level（标记为 deprecated）

Breaking Changes:
- LogConfig 从 core/logger.rs 迁移到 models/config.rs
- 日志系统初始化改为从配置文件读取而非硬编码默认值
- 新增的日志配置字段为 GlobalConfig 的必需组成部分

配置持久化：
- 日志配置保存到 GlobalConfig.log_config
- 支持导入导出配置文件
- 默认配置根据构建模式（debug/release）自动调整