### PR TITLE
fix(tool-detection): 修复工具检测命令解析问题

### DIFF
--- a/src-tauri/src/utils/command.rs
+++ b/src-tauri/src/utils/command.rs
@@ -99,10 +99,14 @@ impl CommandExecutor {
 
     /// 检查命令是否存在
     pub fn command_exists(&self, command: &str) -> bool {
+        // 从命令字符串中提取命令名（第一个词）
+        // 例如: "claude --version" -> "claude"
+        let cmd_name = command.split_whitespace().next().unwrap_or(command);
+
         let check_cmd = if self.platform.is_windows {
-            format!("where {command}")
+            format!("where {cmd_name}")
         } else {
-            format!("which {command}")
+            format!("which {cmd_name}")
         };
 
         self.execute(&check_cmd).success
@@ -110,13 +114,35 @@ impl CommandExecutor {
 
     /// 检查命令是否存在（异步）
     pub async fn command_exists_async(&self, command: &str) -> bool {
+        // 从命令字符串中提取命令名（第一个词）
+        // 例如: "claude --version" -> "claude"
+        let cmd_name = command.split_whitespace().next().unwrap_or(command);
+
         let check_cmd = if self.platform.is_windows {
-            format!("where {command}")
+            format!("where {cmd_name}")
         } else {
-            format!("which {command}")
+            format!("which {cmd_name}")
         };
 
-        self.execute_async(&check_cmd).await.success
+        tracing::info!(
+            "检查命令是否存在: command={}, cmd_name={}, check_cmd={}",
+            command,
+            cmd_name,
+            check_cmd
+        );
+
+        let result = self.execute_async(&check_cmd).await;
+
+        tracing::info!(
+            "命令检查结果: command={}, cmd_name={}, success={}, stdout={:?}, stderr={:?}",
+            command,
+            cmd_name,
+            result.success,
+            result.stdout.trim(),
+            result.stderr.trim()
+        );
+
+        result.success
     }
 }
 


### PR DESCRIPTION
## 问题描述

在使用工具管理功能时发现：
- ✅ "安装工具"页面能正确检测到工具已安装
- ❌ "工具管理"页面显示检测到但未安装
- 两个页面使用不同的检测逻辑导致结果不一致

## 根本原因

`command_exists_async` 方法直接将完整的 check_command（如 `"claude --version"`）传递给 `which`/`where` 命令，但这些命令只接受命令名（如 `"claude"`）作为参数。

**错误示例：**
```bash
# 错误：which 命令不接受参数
which claude --version  # ❌ 失败

# 正确：只传递命令名
which claude  # ✅ 成功
```

## 解决方案

### 1. 修复命令解析 ([command.rs](src-tauri/src/utils/command.rs))

在 `command_exists` 和 `command_exists_async` 方法中：
- 使用 `split_whitespace().next()` 提取命令名（第一个词）
- 只将命令名传递给 `which`/`where`
- 添加详细的日志输出以便调试

**代码变更：**
```rust
// 从命令字符串中提取命令名（第一个词）
// 例如: "claude --version" -> "claude"
let cmd_name = command.split_whitespace().next().unwrap_or(command);

let check_cmd = if self.platform.is_windows {
    format!("where {cmd_name}")
} else {
    format!("which {cmd_name}")
};
```

### 2. 修复刷新逻辑 ([registry.rs](src-tauri/src/services/tool/registry.rs))

修改 `refresh_all` 方法：
- 使用 `detect_single_tool` 并行检测所有工具
- 使用 `upsert_instance` 更新数据库中的实例状态
- 添加详细的日志跟踪检测流程

**核心逻辑：**
```rust
// 并行检测所有工具
let futures: Vec<_> = tools
    .iter()
    .map(|tool| self.detect_single_tool(tool.clone()))
    .collect();

let results = futures_util::future::join_all(futures).await;

// 更新数据库中的实例状态
for instance in results {
    db.upsert_instance(&instance)?;
}
```

## 测试情况

### 代码质量检查
- ✅ `npm run check` 通过所有检查
- ✅ ESLint 检查通过
- ✅ Clippy 检查通过
- ✅ Prettier 格式检查通过
- ✅ cargo fmt 格式检查通过

### 功能测试
需要 reviewer 协助验证：
1. 在"安装工具"页面检测工具状态
2. 在"工具管理"页面刷新工具实例
3. 确认两个页面的检测结果一致

## 影响范围

**修改文件：**
- `src-tauri/src/utils/command.rs` - 命令检测工具类
- `src-tauri/src/services/tool/registry.rs` - 工具注册表服务

**影响功能：**
- 工具安装状态检测
- 工具管理页面刷新逻辑

## 风险评估

- **风险级别**：🟢 低风险
- **向后兼容**：✅ 完全兼容，不破坏现有 API
- **副作用**：无，仅修复 bug
- **回滚计划**：如有问题可直接 revert 此 commit

## Checklist

- [x] 已运行 `npm run check` 且全部通过
- [x] 代码符合项目规范（Conventional Commits）
- [x] 添加了详细的调试日志
- [x] PR 描述清晰完整
- [x] 需要手动功能测试验证