### PR TITLE
feat(theme): 实现侧边栏主题调色盘与自定义主题系统

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 ---
 agents: Codex, Claude-Code, Gemini-Cli
-last-updated: 2025-12-16
+last-updated: 2026-03-12
 ---
 
 # DuckCoding 开发协作规范
@@ -16,6 +16,7 @@ last-updated: 2025-12-16
 - `npm run tauri dev`：本地启动 Tauri 应用进行端到端手动验证。
 - `npm run tauri build`: 本地构建 Tauri 应用安装包。
 - `npm run test` / `npm run test:rs`：后端 Rust 单测（当前无前端测试，test 等同 test:rs）。
+- `npm run test:theme`：前端主题调色盘单测（Vitest），覆盖预设解析、localStorage 回读、CSS 变量映射、颜色转换和自定义调色盘升级逻辑。
 - `cargo test --locked`：Rust 单测执行器；缺乏覆盖时请补测试后再运行。
 - `npm run coverage:rs`：后端覆盖率检查（基于 cargo-llvm-cov，默认行覆盖阈值 90%，需先安装 llvm-tools-preview 与 cargo-llvm-cov，可运行 `npm run coverage:rs:setup` 自动安装依赖）。
 
@@ -331,6 +332,14 @@ last-updated: 2025-12-16
   - `AppContext` 统一管理全局状态（工具状态、配置、更新检查、导航等）
   - `App.tsx` 拆分为 `AppContent`、`AppEventsHandler`、`ConfigWatchHandler`、`UpdateManager`、`OnboardingManager`，引入 `MainLayout` 统一布局
   - 新增复用组件：`ViewToggle`、`BalanceTable`、`HelpDialog`、`ProfileTable`、`ProviderCard`、`TokenCard`、`ToolInstanceCard`
+- **侧边栏主题调色盘（2026-03-12）**：
+  - 主题系统拆分为两层状态：`theme mode`（`light | dark | system`）和 `theme preset`（`default | green | custom`）
+  - `ThemeProvider` 升级为主题管理器：除根节点 `light` / `dark` class 外，还会把活动调色盘写入 CSS 变量，状态持久化到 `localStorage`
+  - 新增存储键：`duckcoding-theme`、`duckcoding-theme-preset`、`duckcoding-theme-palette`
+  - 主题核心逻辑位于 `src/hooks/theme-palette.ts` 与 `src/hooks/theme-storage.ts`，支持内置绿色预设、HSL/Hex 转换、自定义调色盘继承当前预设后再编辑
+  - 侧边栏主题菜单（`AppSidebar`）新增两段式交互：显示模式切换 + 配色方案切换，并提供 `自定义主题...` Dialog 入口
+  - `ThemeCustomizerDialog` 在侧边栏内完成全部主题操作：默认、绿色、自定义切换，以及浅色 / 深色两套 token 的实时编辑和预览
+  - `MainLayout` 的背景渐变改为基于 `background` / `muted` / `accent` token，保证主题骨架能立刻跟随调色盘变化
 - **余额监控页面（BalancePage）**：
   - 后端提供通用 `fetch_api` 命令（位于 `commands/api_commands.rs`），支持 GET/POST、自定义 headers、超时控制
   - 前端使用 JavaScript `Function` 构造器执行用户自定义的 extractor 脚本（位于 `utils/extractor.ts`）

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "duckcoding-setup",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "duckcoding-setup",
-      "version": "1.5.6",
+      "version": "1.5.7",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -65,7 +65,8 @@
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.3.3",
         "typescript-eslint": "^8.46.3",
-        "vite": "^7.2.2"
+        "vite": "^7.2.2",
+        "vitest": "^3.2.4"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -3261,6 +3262,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -3322,6 +3334,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -3668,6 +3687,121 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3919,6 +4053,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -4070,6 +4214,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -4161,6 +4315,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4192,6 +4363,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -4682,6 +4863,16 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4910,6 +5101,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -5335,6 +5533,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5350,6 +5558,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -6549,6 +6767,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6566,6 +6791,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -6932,6 +7167,23 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -7851,6 +8103,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -7873,6 +8132,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -8103,6 +8376,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
@@ -8300,6 +8593,20 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -8346,6 +8653,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -8749,6 +9086,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -8768,6 +9128,92 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
@@ -8883,6 +9329,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "format": "npm run fmt:ts:fix",
     "test": "npm run test:rs",
     "test:rs": "cargo test --manifest-path src-tauri/Cargo.toml --workspace --locked",
+    "test:theme": "vitest run src/hooks/theme-palette.test.ts",
     "coverage:rs": "cargo llvm-cov --manifest-path src-tauri/Cargo.toml --workspace --locked --fail-under-lines 90",
     "coverage:rs:setup": "rustup component add llvm-tools-preview && cargo install cargo-llvm-cov --locked",
     "agent-config:check": "node scripts/ensure-agent-config.mjs --mode=check",
@@ -98,7 +99,8 @@
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.46.3",
-    "vite": "^7.2.2"
+    "vite": "^7.2.2",
+    "vitest": "^3.2.4"
   },
   "engines": {
     "node": ">=20.19.0"

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -15,6 +15,7 @@ import {
   Monitor,
   Info,
   BarChart3,
+  Palette,
 } from 'lucide-react';
 import DuckLogo from '@/assets/duck-logo.png';
 import { useToast } from '@/hooks/use-toast';
@@ -24,10 +25,16 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
+import { ThemeCustomizerDialog } from './ThemeCustomizerDialog';
 
 interface AppSidebarProps {
   activeTab: string;
@@ -78,7 +85,7 @@ export function AppSidebar({
   allowedPage,
 }: AppSidebarProps) {
   const { toast } = useToast();
-  const { actualTheme, setTheme } = useTheme();
+  const { actualTheme, preset, setPreset, setTheme, theme } = useTheme();
 
   // 用户是否手动操作过侧边栏（优先级高于自动折叠）
   const [userHasInteracted, setUserHasInteracted] = useState(() => {
@@ -93,6 +100,7 @@ export function AppSidebar({
     }
     return stored === 'true';
   });
+  const [isThemeDialogOpen, setIsThemeDialogOpen] = useState(false);
 
   // 持久化折叠状态
   useEffect(() => {
@@ -271,16 +279,36 @@ export function AppSidebar({
               <DropdownMenuContent
                 align="start"
                 side={isCollapsed ? 'right' : 'top'}
-                className="w-32"
+                className="w-52"
               >
-                <DropdownMenuItem onClick={() => setTheme('light')}>
-                  <Sun className="mr-2 h-3.5 w-3.5" /> 浅色
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setTheme('dark')}>
-                  <Moon className="mr-2 h-3.5 w-3.5" /> 深色
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setTheme('system')}>
-                  <Monitor className="mr-2 h-3.5 w-3.5" /> 系统
+                <DropdownMenuLabel>显示模式</DropdownMenuLabel>
+                <DropdownMenuRadioGroup
+                  value={theme}
+                  onValueChange={(value) => setTheme(value as typeof theme)}
+                >
+                  <DropdownMenuRadioItem value="light">
+                    <Sun className="mr-2 h-3.5 w-3.5" /> 浅色
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="dark">
+                    <Moon className="mr-2 h-3.5 w-3.5" /> 深色
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="system">
+                    <Monitor className="mr-2 h-3.5 w-3.5" /> 系统
+                  </DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel>配色方案</DropdownMenuLabel>
+                <DropdownMenuRadioGroup
+                  value={preset === 'green' ? 'green' : 'default'}
+                  onValueChange={(value) => setPreset(value as 'default' | 'green')}
+                >
+                  <DropdownMenuRadioItem value="default">默认</DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="green">绿色</DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => setIsThemeDialogOpen(true)}>
+                  <Palette className="mr-2 h-3.5 w-3.5" /> 自定义主题...
+                  {preset === 'custom' && <DropdownMenuShortcut>当前</DropdownMenuShortcut>}
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -306,6 +334,8 @@ export function AppSidebar({
           </div>
         </div>
       </aside>
+
+      <ThemeCustomizerDialog open={isThemeDialogOpen} onOpenChange={setIsThemeDialogOpen} />
     </TooltipProvider>
   );
 }

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -22,7 +22,7 @@ export function MainLayout({ children }: MainLayoutProps) {
       {/* Main Content Area */}
       <main className="flex-1 flex flex-col h-full overflow-hidden relative transition-all duration-300 ease-in-out">
         {/* Background Gradients/Effects can go here */}
-        <div className="absolute inset-0 bg-gradient-to-br from-slate-50/50 to-slate-100/50 dark:from-slate-900/50 dark:to-slate-950/50 -z-10" />
+        <div className="absolute inset-0 -z-10 bg-gradient-to-br from-background via-muted/35 to-accent/30" />
 
         {/* Scrollable Content */}
         <div className="flex-1 overflow-y-auto overflow-x-hidden p-4 custom-scrollbar">

--- a/src/components/layout/ThemeCustomizerDialog.tsx
+++ b/src/components/layout/ThemeCustomizerDialog.tsx
@@ -1,0 +1,189 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useTheme } from '@/hooks/useThemeHook';
+import { hexToHslToken, hslTokenToHex, ThemeTokens } from '@/hooks/theme-palette';
+
+interface ThemeCustomizerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const THEME_FIELDS: Array<{ key: keyof ThemeTokens; label: string; description: string }> = [
+  { key: 'background', label: '背景', description: '页面主背景色' },
+  { key: 'foreground', label: '正文', description: '默认文本颜色' },
+  { key: 'card', label: '卡片', description: '卡片和浮层基础底色' },
+  { key: 'cardForeground', label: '卡片文字', description: '卡片内文本颜色' },
+  { key: 'primary', label: '主色', description: '按钮、选中、高亮' },
+  { key: 'primaryForeground', label: '主色文字', description: '主色按钮上的文字颜色' },
+  { key: 'muted', label: '弱化底色', description: '弱化容器和占位块' },
+  { key: 'mutedForeground', label: '弱化文字', description: '次要说明文字' },
+  { key: 'accent', label: '强调底色', description: '悬浮和辅助高亮' },
+  { key: 'accentForeground', label: '强调文字', description: '强调区域中的文字颜色' },
+  { key: 'border', label: '边框', description: '分割线和边框色' },
+  { key: 'input', label: '输入框', description: '输入边框和输入底色' },
+  { key: 'ring', label: '焦点环', description: '聚焦状态的高亮色' },
+];
+
+function ThemeSection({ mode, title }: { mode: 'light' | 'dark'; title: string }) {
+  const { palette, updatePaletteToken } = useTheme();
+  const tokens = palette[mode];
+
+  return (
+    <section className="space-y-4 rounded-xl border border-border/70 bg-card/70 p-4">
+      <div>
+        <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+        <p className="mt-1 text-xs text-muted-foreground">修改后会立即应用到当前主题系统。</p>
+      </div>
+
+      <div className="space-y-3">
+        {THEME_FIELDS.map((field) => (
+          <div
+            key={`${mode}-${field.key}`}
+            className="grid grid-cols-[120px_1fr_auto] items-center gap-3 rounded-lg border border-border/60 bg-background/70 p-3"
+          >
+            <div>
+              <Label className="text-sm font-medium text-foreground">{field.label}</Label>
+              <p className="mt-1 text-[11px] leading-4 text-muted-foreground">
+                {field.description}
+              </p>
+            </div>
+
+            <Input
+              value={tokens[field.key]}
+              onChange={(event) => updatePaletteToken(mode, field.key, event.target.value)}
+              className="font-mono text-xs"
+            />
+
+            <Input
+              type="color"
+              value={hslTokenToHex(tokens[field.key])}
+              onChange={(event) =>
+                updatePaletteToken(mode, field.key, hexToHslToken(event.target.value))
+              }
+              className="h-10 w-14 cursor-pointer rounded-lg border border-border bg-background p-1"
+              aria-label={`${title}${field.label}`}
+            />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function ThemeCustomizerDialog({ open, onOpenChange }: ThemeCustomizerDialogProps) {
+  const { actualTheme, hasCustomPalette, palette, preset, setPreset, resetPalette } = useTheme();
+  const preview = palette[actualTheme];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-5xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>自定义主题</DialogTitle>
+          <DialogDescription>
+            显示模式仍由浅色、深色、系统控制。这里编辑的是配色预设和浅深两套调色盘。
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          <section
+            className="rounded-2xl border border-border/70 p-5"
+            style={{
+              background: `linear-gradient(135deg, hsl(${preview.background}), hsl(${preview.accent}))`,
+              color: `hsl(${preview.foreground})`,
+            }}
+          >
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div>
+                <p className="text-xs uppercase tracking-[0.2em] opacity-70">Theme Preview</p>
+                <h3 className="mt-2 text-xl font-semibold">
+                  当前为 {actualTheme === 'dark' ? '深色' : '浅色'} 预览
+                </h3>
+                <p className="mt-2 max-w-xl text-sm opacity-80">
+                  当前配色方案：
+                  {preset === 'default' ? ' 默认' : preset === 'green' ? ' 绿色' : ' 自定义'}
+                </p>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  variant={preset === 'default' ? 'default' : 'secondary'}
+                  onClick={() => setPreset('default')}
+                >
+                  使用默认
+                </Button>
+                <Button
+                  type="button"
+                  variant={preset === 'green' ? 'default' : 'secondary'}
+                  onClick={() => setPreset('green')}
+                >
+                  使用绿色
+                </Button>
+                {hasCustomPalette && (
+                  <Button
+                    type="button"
+                    variant={preset === 'custom' ? 'default' : 'secondary'}
+                    onClick={() => setPreset('custom')}
+                  >
+                    使用自定义
+                  </Button>
+                )}
+                <Button type="button" variant="outline" onClick={resetPalette}>
+                  恢复默认
+                </Button>
+              </div>
+            </div>
+
+            <div className="mt-5 grid gap-3 md:grid-cols-3">
+              <div
+                className="rounded-xl border border-black/10 p-4 shadow-sm"
+                style={{
+                  backgroundColor: `hsl(${preview.card})`,
+                  color: `hsl(${preview.cardForeground})`,
+                }}
+              >
+                <p className="text-sm font-semibold">卡片预览</p>
+                <p className="mt-2 text-xs opacity-80">卡片、面板和多数容器会跟随这里的 token。</p>
+              </div>
+              <div
+                className="rounded-xl border border-black/10 p-4 shadow-sm"
+                style={{
+                  backgroundColor: `hsl(${preview.primary})`,
+                  color: `hsl(${preview.primaryForeground})`,
+                }}
+              >
+                <p className="text-sm font-semibold">主按钮</p>
+                <p className="mt-2 text-xs opacity-90">主按钮、选中导航和焦点色会使用这组颜色。</p>
+              </div>
+              <div
+                className="rounded-xl border border-black/10 p-4 shadow-sm"
+                style={{
+                  backgroundColor: `hsl(${preview.muted})`,
+                  color: `hsl(${preview.mutedForeground})`,
+                }}
+              >
+                <p className="text-sm font-semibold">弱化区域</p>
+                <p className="mt-2 text-xs opacity-90">
+                  说明文字、浅背景和辅助区域会跟随这组颜色。
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <div className="grid gap-4 xl:grid-cols-2">
+            <ThemeSection mode="light" title="浅色调色盘" />
+            <ThemeSection mode="dark" title="深色调色盘" />
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/hooks/theme-context.ts
+++ b/src/hooks/theme-context.ts
@@ -1,11 +1,18 @@
 import { createContext } from 'react';
+import { ActualTheme, ThemeMode, ThemePalette, ThemePreset, ThemeTokens } from './theme-palette';
 
-export type Theme = 'light' | 'dark' | 'system';
+export type Theme = ThemeMode;
 
 export interface ThemeContextType {
   theme: Theme;
-  actualTheme: 'light' | 'dark'; // 实际应用的主题（考虑系统设置）
+  actualTheme: ActualTheme; // 实际应用的主题（考虑系统设置）
+  preset: ThemePreset;
+  palette: ThemePalette;
+  hasCustomPalette: boolean;
   setTheme: (theme: Theme) => void;
+  setPreset: (preset: ThemePreset) => void;
+  updatePaletteToken: (mode: ActualTheme, token: keyof ThemeTokens, value: string) => void;
+  resetPalette: () => void;
 }
 
 export const ThemeContext = createContext<ThemeContextType | undefined>(undefined);

--- a/src/hooks/theme-palette.test.ts
+++ b/src/hooks/theme-palette.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyThemeToRoot,
+  buildCssVariables,
+  createCustomPaletteUpdate,
+  DEFAULT_THEME_PALETTE,
+  GREEN_THEME_PALETTE,
+  hexToHslToken,
+  hslTokenToHex,
+  mergeThemePalette,
+  resolveActualTheme,
+  resolveActivePalette,
+} from './theme-palette';
+import {
+  readStoredPalette,
+  readStoredThemeMode,
+  readStoredThemePreset,
+  THEME_STORAGE_KEYS,
+} from './theme-storage';
+
+describe('theme palette helpers', () => {
+  it('returns default palette when preset is default', () => {
+    const palette = resolveActivePalette('default', null);
+
+    expect(palette).toEqual(DEFAULT_THEME_PALETTE);
+  });
+
+  it('returns built-in green palette when preset is green', () => {
+    const palette = resolveActivePalette('green', null);
+
+    expect(palette).toEqual(GREEN_THEME_PALETTE);
+  });
+
+  it('merges custom palette values over defaults', () => {
+    const palette = mergeThemePalette({
+      light: {
+        primary: '142 71% 45%',
+      },
+      dark: {
+        background: '152 40% 8%',
+      },
+    });
+
+    expect(palette.light.primary).toBe('142 71% 45%');
+    expect(palette.light.background).toBe(DEFAULT_THEME_PALETTE.light.background);
+    expect(palette.dark.background).toBe('152 40% 8%');
+    expect(palette.dark.primary).toBe(DEFAULT_THEME_PALETTE.dark.primary);
+  });
+
+  it('maps palette tokens to CSS custom properties', () => {
+    const cssVariables = buildCssVariables(DEFAULT_THEME_PALETTE.light);
+
+    expect(cssVariables).toMatchObject({
+      '--background': DEFAULT_THEME_PALETTE.light.background,
+      '--foreground': DEFAULT_THEME_PALETTE.light.foreground,
+      '--card-foreground': DEFAULT_THEME_PALETTE.light.cardForeground,
+      '--primary': DEFAULT_THEME_PALETTE.light.primary,
+      '--primary-foreground': DEFAULT_THEME_PALETTE.light.primaryForeground,
+      '--accent': DEFAULT_THEME_PALETTE.light.accent,
+      '--accent-foreground': DEFAULT_THEME_PALETTE.light.accentForeground,
+      '--border': DEFAULT_THEME_PALETTE.light.border,
+      '--input': DEFAULT_THEME_PALETTE.light.input,
+      '--ring': DEFAULT_THEME_PALETTE.light.ring,
+    });
+  });
+
+  it('resolves actual theme from system mode and system preference', () => {
+    expect(resolveActualTheme('system', 'dark')).toBe('dark');
+    expect(resolveActualTheme('system', 'light')).toBe('light');
+    expect(resolveActualTheme('dark', 'light')).toBe('dark');
+  });
+
+  it('reads stored theme settings with safe fallbacks', () => {
+    const storage = new Map<string, string>([
+      [THEME_STORAGE_KEYS.mode, 'dark'],
+      [THEME_STORAGE_KEYS.preset, 'green'],
+      [
+        THEME_STORAGE_KEYS.palette,
+        JSON.stringify({
+          light: { primary: '142 71% 45%' },
+        }),
+      ],
+    ]);
+
+    const read = (key: string) => storage.get(key) ?? null;
+
+    expect(readStoredThemeMode(read)).toBe('dark');
+    expect(readStoredThemePreset(read)).toBe('green');
+    expect(readStoredPalette(read)).toEqual({
+      light: { primary: '142 71% 45%' },
+    });
+  });
+
+  it('applies theme class and CSS variables to the root target', () => {
+    const classes = new Set<string>(['light']);
+    const styles = new Map<string, string>();
+
+    const root = {
+      classList: {
+        add: (...values: string[]) => values.forEach((value) => classes.add(value)),
+        remove: (...values: string[]) => values.forEach((value) => classes.delete(value)),
+      },
+      style: {
+        setProperty: (key: string, value: string) => {
+          styles.set(key, value);
+        },
+      },
+    };
+
+    applyThemeToRoot(root, 'dark', GREEN_THEME_PALETTE.dark);
+
+    expect(classes.has('light')).toBe(false);
+    expect(classes.has('dark')).toBe(true);
+    expect(styles.get('--primary')).toBe(GREEN_THEME_PALETTE.dark.primary);
+    expect(styles.get('--accent-foreground')).toBe(GREEN_THEME_PALETTE.dark.accentForeground);
+  });
+
+  it('converts theme tokens between HSL and hex for color inputs', () => {
+    expect(hslTokenToHex('226 70% 55.5%')).toBe('#3e63dd');
+    expect(hexToHslToken('#16a34a')).toBe('142 76.2% 36.3%');
+  });
+
+  it('promotes the active preset palette to custom before editing a token', () => {
+    const result = createCustomPaletteUpdate({
+      preset: 'green',
+      customPalette: null,
+      mode: 'dark',
+      token: 'background',
+      value: '155 30% 12%',
+    });
+
+    expect(result.preset).toBe('custom');
+    expect(result.palette.dark.background).toBe('155 30% 12%');
+    expect(result.palette.dark.primary).toBe(GREEN_THEME_PALETTE.dark.primary);
+    expect(result.palette.light.primary).toBe(GREEN_THEME_PALETTE.light.primary);
+  });
+});

--- a/src/hooks/theme-palette.ts
+++ b/src/hooks/theme-palette.ts
@@ -1,0 +1,305 @@
+export type ThemeMode = 'light' | 'dark' | 'system';
+
+export type ThemePreset = 'default' | 'green' | 'custom';
+
+export interface ThemeTokens {
+  background: string;
+  foreground: string;
+  card: string;
+  cardForeground: string;
+  popover: string;
+  popoverForeground: string;
+  primary: string;
+  primaryForeground: string;
+  secondary: string;
+  secondaryForeground: string;
+  muted: string;
+  mutedForeground: string;
+  border: string;
+  input: string;
+  ring: string;
+  accent: string;
+  accentForeground: string;
+}
+
+export interface ThemePalette {
+  light: ThemeTokens;
+  dark: ThemeTokens;
+}
+
+export type ActualTheme = 'light' | 'dark';
+
+export type ThemePaletteInput = Partial<{
+  light: Partial<ThemeTokens>;
+  dark: Partial<ThemeTokens>;
+}>;
+
+const CSS_VARIABLE_MAP: Record<keyof ThemeTokens, string> = {
+  background: '--background',
+  foreground: '--foreground',
+  card: '--card',
+  cardForeground: '--card-foreground',
+  popover: '--popover',
+  popoverForeground: '--popover-foreground',
+  primary: '--primary',
+  primaryForeground: '--primary-foreground',
+  secondary: '--secondary',
+  secondaryForeground: '--secondary-foreground',
+  muted: '--muted',
+  mutedForeground: '--muted-foreground',
+  border: '--border',
+  input: '--input',
+  ring: '--ring',
+  accent: '--accent',
+  accentForeground: '--accent-foreground',
+};
+
+export const DEFAULT_THEME_PALETTE: ThemePalette = {
+  light: {
+    background: '0 0% 100%',
+    foreground: '240 10% 3.9%',
+    card: '0 0% 100%',
+    cardForeground: '240 10% 3.9%',
+    popover: '0 0% 100%',
+    popoverForeground: '240 10% 3.9%',
+    primary: '226 70% 55.5%',
+    primaryForeground: '0 0% 98%',
+    secondary: '240 4.8% 95.9%',
+    secondaryForeground: '240 5.9% 10%',
+    muted: '240 4.8% 95.9%',
+    mutedForeground: '240 3.8% 46.1%',
+    border: '240 5.9% 90%',
+    input: '240 5.9% 90%',
+    ring: '226 70% 55.5%',
+    accent: '240 4.8% 95.9%',
+    accentForeground: '240 5.9% 10%',
+  },
+  dark: {
+    background: '240 10% 3.9%',
+    foreground: '0 0% 98%',
+    card: '240 10% 3.9%',
+    cardForeground: '0 0% 98%',
+    popover: '240 10% 3.9%',
+    popoverForeground: '0 0% 98%',
+    primary: '226 70% 55.5%',
+    primaryForeground: '0 0% 98%',
+    secondary: '240 3.7% 15.9%',
+    secondaryForeground: '0 0% 98%',
+    muted: '240 3.7% 15.9%',
+    mutedForeground: '240 5% 64.9%',
+    border: '240 3.7% 15.9%',
+    input: '240 3.7% 15.9%',
+    ring: '226 70% 55.5%',
+    accent: '240 3.7% 15.9%',
+    accentForeground: '0 0% 98%',
+  },
+};
+
+export const GREEN_THEME_PALETTE: ThemePalette = {
+  light: {
+    ...DEFAULT_THEME_PALETTE.light,
+    primary: '142 71% 45%',
+    primaryForeground: '138 76% 97%',
+    ring: '142 71% 45%',
+    accent: '138 47% 96%',
+    accentForeground: '142 72% 20%',
+  },
+  dark: {
+    ...DEFAULT_THEME_PALETTE.dark,
+    primary: '142 69% 45%',
+    primaryForeground: '144 61% 10%',
+    ring: '142 69% 45%',
+    accent: '142 32% 18%',
+    accentForeground: '138 76% 97%',
+  },
+};
+
+export function mergeThemePalette(input?: ThemePaletteInput | null): ThemePalette {
+  return {
+    light: {
+      ...DEFAULT_THEME_PALETTE.light,
+      ...(input?.light ?? {}),
+    },
+    dark: {
+      ...DEFAULT_THEME_PALETTE.dark,
+      ...(input?.dark ?? {}),
+    },
+  };
+}
+
+export function resolveActivePalette(
+  preset: ThemePreset,
+  customPalette?: ThemePaletteInput | null,
+): ThemePalette {
+  if (preset === 'green') {
+    return GREEN_THEME_PALETTE;
+  }
+
+  if (preset === 'custom') {
+    return mergeThemePalette(customPalette);
+  }
+
+  return DEFAULT_THEME_PALETTE;
+}
+
+export function buildCssVariables(tokens: ThemeTokens): Record<string, string> {
+  return Object.entries(CSS_VARIABLE_MAP).reduce<Record<string, string>>((acc, [key, variable]) => {
+    acc[variable] = tokens[key as keyof ThemeTokens];
+    return acc;
+  }, {});
+}
+
+export function resolveActualTheme(mode: ThemeMode, systemTheme: ActualTheme): ActualTheme {
+  return mode === 'system' ? systemTheme : mode;
+}
+
+interface RootThemeTarget {
+  classList: {
+    add: (...tokens: string[]) => void;
+    remove: (...tokens: string[]) => void;
+  };
+  style: {
+    setProperty: (property: string, value: string) => void;
+  };
+}
+
+export function applyThemeToRoot(
+  root: RootThemeTarget,
+  actualTheme: ActualTheme,
+  tokens: ThemeTokens,
+): void {
+  root.classList.remove('light', 'dark');
+  root.classList.add(actualTheme);
+
+  const cssVariables = buildCssVariables(tokens);
+  Object.entries(cssVariables).forEach(([key, value]) => {
+    root.style.setProperty(key, value);
+  });
+}
+
+function formatHue(hue: number): string {
+  return String(Math.round(hue));
+}
+
+function formatPercent(value: number): string {
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}
+
+function clampRgbChannel(value: number): number {
+  return Math.max(0, Math.min(255, Math.round(value)));
+}
+
+export function hslTokenToHex(token: string): string {
+  const [hRaw, sRaw, lRaw] = token.trim().split(/\s+/);
+  const hue = Number.parseFloat(hRaw);
+  const saturation = Number.parseFloat(sRaw.replace('%', '')) / 100;
+  const lightness = Number.parseFloat(lRaw.replace('%', '')) / 100;
+
+  if ([hue, saturation, lightness].some((value) => Number.isNaN(value))) {
+    return '#000000';
+  }
+
+  const chroma = (1 - Math.abs(2 * lightness - 1)) * saturation;
+  const hueSection = hue / 60;
+  const x = chroma * (1 - Math.abs((hueSection % 2) - 1));
+  const match = lightness - chroma / 2;
+
+  let red = 0;
+  let green = 0;
+  let blue = 0;
+
+  if (hueSection >= 0 && hueSection < 1) {
+    red = chroma;
+    green = x;
+  } else if (hueSection < 2) {
+    red = x;
+    green = chroma;
+  } else if (hueSection < 3) {
+    green = chroma;
+    blue = x;
+  } else if (hueSection < 4) {
+    green = x;
+    blue = chroma;
+  } else if (hueSection < 5) {
+    red = x;
+    blue = chroma;
+  } else {
+    red = chroma;
+    blue = x;
+  }
+
+  const toHex = (value: number) =>
+    clampRgbChannel((value + match) * 255)
+      .toString(16)
+      .padStart(2, '0');
+  return `#${toHex(red)}${toHex(green)}${toHex(blue)}`;
+}
+
+export function hexToHslToken(hex: string): string {
+  const normalized = hex.replace('#', '');
+  if (normalized.length !== 3 && normalized.length !== 6) {
+    return DEFAULT_THEME_PALETTE.light.primary;
+  }
+  const expanded =
+    normalized.length === 3
+      ? normalized
+          .split('')
+          .map((part) => `${part}${part}`)
+          .join('')
+      : normalized;
+
+  const red = Number.parseInt(expanded.slice(0, 2), 16) / 255;
+  const green = Number.parseInt(expanded.slice(2, 4), 16) / 255;
+  const blue = Number.parseInt(expanded.slice(4, 6), 16) / 255;
+
+  const max = Math.max(red, green, blue);
+  const min = Math.min(red, green, blue);
+  const delta = max - min;
+  const lightness = (max + min) / 2;
+
+  let hue = 0;
+  if (delta !== 0) {
+    if (max === red) {
+      hue = ((green - blue) / delta) % 6;
+    } else if (max === green) {
+      hue = (blue - red) / delta + 2;
+    } else {
+      hue = (red - green) / delta + 4;
+    }
+  }
+  hue = Math.round((hue * 60 + 360) % 360);
+
+  const saturation = delta === 0 ? 0 : delta / (1 - Math.abs(2 * lightness - 1));
+
+  return `${formatHue(hue)} ${formatPercent(saturation * 100)}% ${formatPercent(lightness * 100)}%`;
+}
+
+interface CustomPaletteUpdateInput {
+  preset: ThemePreset;
+  customPalette?: ThemePaletteInput | null;
+  mode: 'light' | 'dark';
+  token: keyof ThemeTokens;
+  value: string;
+}
+
+export function createCustomPaletteUpdate({
+  preset,
+  customPalette,
+  mode,
+  token,
+  value,
+}: CustomPaletteUpdateInput): { preset: ThemePreset; palette: ThemePalette } {
+  const basePalette = resolveActivePalette(preset, customPalette);
+  return {
+    preset: 'custom',
+    palette: {
+      light: { ...basePalette.light },
+      dark: { ...basePalette.dark },
+      [mode]: {
+        ...basePalette[mode],
+        [token]: value,
+      },
+    },
+  };
+}

--- a/src/hooks/theme-storage.ts
+++ b/src/hooks/theme-storage.ts
@@ -1,0 +1,40 @@
+import { ThemeMode, ThemePaletteInput, ThemePreset } from './theme-palette';
+
+export const THEME_STORAGE_KEYS = {
+  mode: 'duckcoding-theme',
+  preset: 'duckcoding-theme-preset',
+  palette: 'duckcoding-theme-palette',
+} as const;
+
+type StorageReader = (key: string) => string | null;
+
+function isThemeMode(value: string | null): value is ThemeMode {
+  return value === 'light' || value === 'dark' || value === 'system';
+}
+
+function isThemePreset(value: string | null): value is ThemePreset {
+  return value === 'default' || value === 'green' || value === 'custom';
+}
+
+export function readStoredThemeMode(read: StorageReader): ThemeMode {
+  const value = read(THEME_STORAGE_KEYS.mode);
+  return isThemeMode(value) ? value : 'system';
+}
+
+export function readStoredThemePreset(read: StorageReader): ThemePreset {
+  const value = read(THEME_STORAGE_KEYS.preset);
+  return isThemePreset(value) ? value : 'default';
+}
+
+export function readStoredPalette(read: StorageReader): ThemePaletteInput | null {
+  const raw = read(THEME_STORAGE_KEYS.palette);
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(raw) as ThemePaletteInput;
+  } catch {
+    return null;
+  }
+}

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -1,51 +1,110 @@
 import { useEffect, useState } from 'react';
 import { Theme, ThemeContext } from './theme-context';
+import {
+  applyThemeToRoot,
+  createCustomPaletteUpdate,
+  resolveActivePalette,
+  resolveActualTheme,
+  ThemeTokens,
+} from './theme-palette';
+import {
+  readStoredPalette,
+  readStoredThemeMode,
+  readStoredThemePreset,
+  THEME_STORAGE_KEYS,
+} from './theme-storage';
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  // 从 localStorage 读取主题设置，默认为 system
   const [theme, setThemeState] = useState<Theme>(() => {
-    const stored = localStorage.getItem('duckcoding-theme');
-    return (stored as Theme) || 'system';
+    return readStoredThemeMode((key) => localStorage.getItem(key));
   });
 
-  // 获取系统主题偏好
+  const [preset, setPresetState] = useState(() =>
+    readStoredThemePreset((key) => localStorage.getItem(key)),
+  );
+
+  const [customPalette, setCustomPalette] = useState(() =>
+    readStoredPalette((key) => localStorage.getItem(key)),
+  );
+
   const getSystemTheme = (): 'light' | 'dark' => {
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   };
 
-  // 计算实际应用的主题
-  const actualTheme: 'light' | 'dark' = theme === 'system' ? getSystemTheme() : theme;
+  const [systemTheme, setSystemTheme] = useState<'light' | 'dark'>(() => getSystemTheme());
 
-  // 设置主题
+  const actualTheme = resolveActualTheme(theme, systemTheme);
+  const palette = resolveActivePalette(preset, customPalette);
+
   const setTheme = (newTheme: Theme) => {
     setThemeState(newTheme);
-    localStorage.setItem('duckcoding-theme', newTheme);
   };
 
-  // 应用主题到 DOM
-  useEffect(() => {
-    const root = window.document.documentElement;
-    root.classList.remove('light', 'dark');
-    root.classList.add(actualTheme);
-  }, [actualTheme]);
+  const setPreset = (newPreset: typeof preset) => {
+    setPresetState(newPreset);
+  };
 
-  // 监听系统主题变化
-  useEffect(() => {
-    if (theme !== 'system') return;
+  const updatePaletteToken = (mode: 'light' | 'dark', token: keyof ThemeTokens, value: string) => {
+    const next = createCustomPaletteUpdate({
+      preset,
+      customPalette,
+      mode,
+      token,
+      value,
+    });
+    setPresetState(next.preset);
+    setCustomPalette(next.palette);
+  };
 
+  const resetPalette = () => {
+    setPresetState('default');
+    setCustomPalette(null);
+  };
+
+  useEffect(() => {
+    applyThemeToRoot(window.document.documentElement, actualTheme, palette[actualTheme]);
+  }, [actualTheme, palette]);
+
+  useEffect(() => {
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
     const handleChange = () => {
-      const root = window.document.documentElement;
-      root.classList.remove('light', 'dark');
-      root.classList.add(getSystemTheme());
+      setSystemTheme(getSystemTheme());
     };
 
     mediaQuery.addEventListener('change', handleChange);
     return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(THEME_STORAGE_KEYS.mode, theme);
   }, [theme]);
 
+  useEffect(() => {
+    localStorage.setItem(THEME_STORAGE_KEYS.preset, preset);
+  }, [preset]);
+
+  useEffect(() => {
+    if (customPalette) {
+      localStorage.setItem(THEME_STORAGE_KEYS.palette, JSON.stringify(customPalette));
+      return;
+    }
+    localStorage.removeItem(THEME_STORAGE_KEYS.palette);
+  }, [customPalette]);
+
   return (
-    <ThemeContext.Provider value={{ theme, actualTheme, setTheme }}>
+    <ThemeContext.Provider
+      value={{
+        theme,
+        actualTheme,
+        preset,
+        palette,
+        hasCustomPalette: customPalette !== null,
+        setTheme,
+        setPreset,
+        updatePaletteToken,
+        resetPalette,
+      }}
+    >
       {children}
     </ThemeContext.Provider>
   );


### PR DESCRIPTION
Implement sidebar theme palette and custom theme system

重构主题系统，支持主题模式（亮/暗/系统）与配色方案（默认/绿色/自定义）的双层架构
Refactor theme system to support dual-layer architecture: theme mode and color preset 升级 ThemeProvider，实现 CSS 变量映射、状态持久化及调色盘自动应用
Upgrade ThemeProvider with CSS variable mapping, state persistence, and automatic palette application 新增 ThemeCustomizerDialog 及侧边栏菜单，支持 HSL/Hex 颜色实时预览与编辑 Add ThemeCustomizerDialog and sidebar menu for real-time HSL/Hex color preview and editing 引入 Vitest 单元测试覆盖调色盘解析、CSS 变量映射及自定义逻辑
Introduce Vitest unit tests covering palette parsing, CSS variable mapping, and custom logic 优化 MainLayout 背景渐变，使其响应动态主题 Token 变化
Optimize MainLayout background gradient to respond to dynamic theme token changes